### PR TITLE
Add documentation with MkDocs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to Doglang Documentation
+
+Thank you for your interest in improving Doglang! We welcome contributions from everyone, whether you are fixing typos, clarifying explanations, or adding new sections.
+
+Here’s how you can help:
+
+---
+
+## Editing Documentation
+
+All documentation files are Markdown (`.md`) files located inside the `/docs` folder in the repository.
+
+- To make changes, simply edit the relevant `.md` files.
+- You can add new files or update existing ones to improve clarity, add examples, or fix mistakes.
+
+---
+
+## Previewing Documentation Locally
+
+Before submitting your changes, it’s a good idea to preview how the documentation will look on the website.
+
+1. Install MkDocs if you haven’t already:
+```bash
+pip install mkdocs
+```
+
+2. From the project root directory, run:
+```bash
+mkdocs serve
+```
+
+3. Open your browser at [http://127.0.0.1:8000/](http://127.0.0.1:8000/) to see a live preview.
+
+When you save your Markdown files, the preview will update automatically.
+
+---
+
+## Submitting Changes
+
+1. Fork the Doglang repository to your own GitHub account.
+2. Create a branch for your changes (e.g., `improve-docs`).
+3. Make your edits and commit them with clear messages.
+4. Push your branch to your fork.
+5. Open a Pull Request (PR) from your branch to the original repository’s `main` branch.
+
+We review all pull requests promptly and provide feedback if necessary.
+
+---
+
+## Reporting Issues or Suggesting Features
+
+If you find errors, have questions, or want to suggest new documentation topics or features, please open an issue on the Doglang GitHub repository.
+
+Provide as much detail as possible so we can address your concern quickly.
+
+---
+
+## Our Commitment
+
+We believe in open and collaborative documentation to help everyone learn Doglang easily. Your feedback and contributions make this project better for the whole community!
+
+Thank you for being part of the Doglang pack!
+
+---
+
+*Happy coding and documenting!* 🐾
+

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,76 @@
+# Frequently Asked Questions (FAQ)
+
+---
+
+## What file extension do Doglang programs use?
+
+Doglang source code files use the `.doggy` extension.
+
+---
+
+## How do I run a Doglang program?
+
+If Doglang is installed via PyPI, run:
+```bash
+doglang -f your_program.doggy
+```
+
+If running from the cloned repository, use:
+```bash
+python doglang.py -f your_program.doggy
+```
+
+You can also execute inline code with the `-e` option:
+```bash
+doglang -e "a = 10; bark(a);"
+```
+
+---
+
+## What data types does Doglang support?
+
+Currently, Doglang supports only **integers** and **strings**.
+
+---
+
+## Are functions supported in Doglang?
+
+No, Doglang does not yet support user-defined functions or procedures.
+
+---
+
+## How does Doglang handle errors?
+
+Doglang provides basic error messages and reports syntax or runtime errors simply without detailed debugging information.
+
+---
+
+## Can I contribute to Doglang?
+
+Absolutely! Contributions are welcome from users of all experience levels. You can:
+
+- Improve or add features
+- Fix bugs
+- Enhance the documentation
+- Suggest new dog-themed commands or capabilities
+
+See the **Contributing** section in the documentation for details on submitting pull requests and reporting issues.
+
+---
+
+## Where can I find more documentation?
+
+Full documentation and usage examples are available online at:
+
+[https://pallavrai.github.io/Doglang](https://pallavrai.github.io/Doglang)
+
+---
+
+## Who created Doglang?
+
+Doglang is a fun open-source project created by Pallavrai to bring a playful spin to learning programming.
+
+---
+
+If you have other questions, feel free to open an issue on the GitHub repository.
+

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,85 @@
+# Overview of language features
+
+Doglang combines a fun dog-inspired syntax with core programming constructs to make coding enjoyable and easy to learn. Below is an overview of its main features:
+
+---
+
+## Core Language Constructs
+
+- **Variable Assignment**  
+  Assign values to variables without explicit type declarations:
+```bash
+a = 10;
+```
+
+- **Print Statement (`bark`)**  
+Print values or messages to the console:
+```bash
+bark("Hello, Doglang!");
+bark(a);
+```
+
+- **Loops (`wagtail`)**  
+Loop while a condition is true:
+```bash
+wagtail(a < 5) {
+bark(a);
+a = a + 1;
+}
+```
+
+- **Conditionals (`sniff` / `else`)**  
+Branch execution based on conditions:
+```bash
+sniff(a == 10) {
+bark("Ten!");
+} else {
+bark("Not ten.");
+}
+```
+
+- **Input (`fetch`)**  
+Get user input during program execution:
+```bash
+name = fetch("Enter your name: ");
+```
+
+---
+
+## Supported Operators
+
+- Arithmetic:  
+`+`, `-`, `*`, `/`, `%`
+
+- Comparison:  
+`==`, `!=`, `<`, `>`, `<=`, `>=`
+
+- Assignment:  
+`=`
+
+---
+
+## File Extension
+
+- Doglang source files use the `.doggy` extension.
+
+---
+
+## Limitations
+
+- Currently supports only integer and string data types.
+- No functions or user-defined procedures yet.
+- Basic error reporting without detailed debug info.
+
+---
+
+## Tips for Writing Doglang Code
+
+- End each statement with a semicolon (`;`).
+- Enclose code blocks in curly braces `{}`.
+- Variables are dynamically typed (no need to declare type).
+
+---
+
+Doglang is actively evolving, and new features are planned. Contributions and suggestions are always welcome!
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,7 @@
+# Welcome to Doglang — The Playful Language for Programmers with a Woof!
+
+Imagine a programming language inspired by the joyful spirit and playful nature of our canine companions. Doglang is not just any interpreter — it's a fun-filled, tail-wagging experience that turns coding into a game where commands speak “dog”. With `bark` to print your messages, `wagtail` to loop endlessly in joy, and `sniff` for curious conditionals, Doglang invites developers to fetch creativity and sniff out new programming horizons.
+
+Built as an interpreted language for beginners and pros alike, Doglang takes you on a walk through core programming concepts with a furry twist. Whether you're chasing variables, digging through loops, or fetching input, every line of code barks with personality.
+
+Join this pack of enthusiastic coders as Doglang grows into a powerful yet playful language designed to keep learning entertaining. Let’s unleash the dog lover in every programmer and make coding as fun as a day at the dog park!

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,106 @@
+# Installation and setup instructions
+
+Welcome to Doglang! Follow the instructions below to get started quickly with installing and running Doglang on your machine.
+
+## Option 1: Install from PyPI (Recommended)
+
+The easiest way to install Doglang is via Python's package manager `pip`. This option installs Doglang globally so you can run it from the command line anywhere.
+
+### Requirements
+- Python 3.7 or higher
+- pip installed (usually included with Python)
+
+### Installation Command
+
+Open your terminal or command prompt and run:
+```bash
+pip install doglang
+```
+
+### Verify Installation
+
+To verify Doglang was installed successfully, run:
+```bash
+doglang --help
+```
+
+This should display the Doglang command line usage information.
+
+---
+
+## Option 2: Clone from GitHub
+
+You can also clone the Doglang source repository to your local machine and run it directly.
+
+### Steps
+
+1. Clone the repository:
+```bash
+git clone https://github.com/Pallavrai/Doglang.git
+```
+
+2. Change into the project directory:
+```bash
+cd Doglang
+```
+
+3. (Optional) It is recommended to use a Python virtual environment:
+```bash
+python -m venv venv
+source venv/bin/activate # On Windows use venv\Scripts\activate
+```
+
+4. Install required dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Running Doglang Programs
+
+### Running a program from a file
+
+If you cloned the repo, run:
+```bash
+python doglang.py -f your_program.doggy
+```
+
+If installed via PyPI:
+```bash
+doglang -f your_program.doggy
+```
+
+### Running code directly from command line
+
+Execute inline commands:
+
+If cloned:
+```bash
+python doglang.py -e "a = 10; bark(a);"
+```
+
+---
+
+## Additional Options
+
+- To see the tokens generated from your code (for debugging):
+```bash
+doglang -f your_program.doggy --tokens
+```
+
+---
+
+## Notes
+
+- Doglang source files use the `.doggy` extension.
+- Make sure your Python environment is set up correctly for the above commands to work.
+- If you encounter issues, check your Python and pip versions or raise an issue in the GitHub repo.
+
+---
+
+Enjoy coding with Doglang!
+
+
+
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,82 @@
+# Usage examples with code snippets
+
+This section provides basic examples to help you get started with writing Doglang programs.
+
+---
+
+## Variable Assignment
+
+Assign a value to a variable using the equals sign (`=`):
+```bash
+a = 10 ;
+```
+
+---
+
+## Print Statement (`bark`)
+
+Use the `bark` command to print values or messages:
+```bash
+bark(a);
+bark("Hello, Doglang!");
+```
+
+---
+
+## Loop Statement (`wagtail`)
+
+The `wagtail` keyword starts a loop which runs while the condition is true:
+```bash
+a = 0;
+wagtail(a < 5) {
+bark(a);
+a = a + 1;
+}
+```
+
+This loops from 0 to 4, printing each value.
+
+---
+
+## Conditional Statement (`sniff`)
+
+Use `sniff` to check conditions and optionally `else` for alternate execution:
+```bash
+a = 10;
+sniff(a % 2 == 0) {
+bark("Even");
+} else {
+bark("Odd");
+}
+```
+
+This prints "Even" if `a` is even, otherwise prints "Odd".
+
+---
+
+## Input Statement (`fetch`)
+
+Prompt the user for input using `fetch`:
+```bash
+name = fetch("Enter your name: ");
+bark("Hello, " + name + "!");
+```
+
+---
+
+## Running Doglang Code from Command Line
+
+### From File
+```bash
+doglang -f your_program.doggy
+```
+
+### Inline Code Execution
+```bash
+doglang -e "a = 10; bark(a);"
+```
+
+---
+
+Explore these examples and start creating your own fun Doglang programs!
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: Doglang Documentation
+site_url: https://pallavrai.github.io/Doglang
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Usage: usage.md
+  - Features: features.md
+  - FAQ: faq.md
+  - Contributing: CONTRIBUTING.md
+theme:
+  name: readthedocs
+docs_dir: docs
+repo_url: https://github.com/pallavrai/Doglang


### PR DESCRIPTION
# Add Documentation with MkDocs

This pull request introduces a complete documentation setup for Doglang using MkDocs, including:

- A new `/docs` folder containing detailed Markdown documentation files:
  - `index.md`: Introduction to Doglang
  - `installation.md`: Installation instructions
  - `usage.md`: Usage examples
  - `features.md`: Language features overview
  - `faq.md`: Frequently asked questions
  - `contributing.md`: Guide for contributing to documentation and project

- A `mkdocs.yml` configuration file to define the site structure and theme.

- Instructions and resources to preview the documentation locally using MkDocs.

- Ready-to-publish static documentation setup compatible with GitHub Pages for easy hosting.

This addition aims to improve onboarding for new learners and contributors by providing clear and accessible resources for Doglang.

Please review and provide feedback or suggestions for further improvements.
