### PR TITLE
Add PR labeler workflow for Hacktoberfest

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,27 @@
+name: "PR Labeler for Hacktoberfest"
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # ✅ allow labeling
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Label PR for Hacktoberfest
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            good first issue
+            hacktoberfest
+            hacktoberfest2025
+            hacktoberfest-accepted


### PR DESCRIPTION
Automated workflow to label pull requests for Hacktoberfest participation.

### Benefits
- Streamlines Hacktoberfest PR validation
- Reduces manual labeling effort for maintainers
- Ensures contributors get proper credit automatically
- Improves contributor experience during Hacktoberfest

Closes #13 
