### PR TITLE
fix(interpreter): Isolate symbol table to prevent state leak

### DIFF
--- a/doglang/SymbolTable.py
+++ b/doglang/SymbolTable.py
@@ -1,24 +1,25 @@
 """Symbol Table(name,type,scope,value)"""
-symbols=[]
+
 class SymbolTable:
-    def __init__(self,name="",type="",scope="",value=""):
-        self.name=name
-        self.type=type
-        self.scope=scope
-        self.value=value
+    # __init__ creates an instance-specific list.
+    def __init__(self):
+        self.symbols=[]
 
     def insert(self,name,type,scope,value):
-        symbols.append(SymbolTable(name,type,scope,value))
+
+        symbol_entry = {'name': name, 'type': type, 'scope': scope, 'value': value}
+        self.symbols.append(symbol_entry)
     
     def lookup(self,name):
-        for entry in symbols:
-            if entry.name==name:
-                return entry
+        for entry in self.symbols:
+            if entry['name']==name:
+                return entry     # Returns the dictionary
         return None
     
+    # modifies the instance list.
     def modify(self,name,value):
-        for entry in symbols:
-            if entry.name==name:
-                entry.value=value
+        for entry in self.symbols:
+            if entry['name']==name:
+                entry['value']=value
                 return
         return None

--- a/doglang/main.py
+++ b/doglang/main.py
@@ -87,7 +87,7 @@ class Interpreter:
                 if self.symbol_table.lookup(child.value) is None:
                     raise Exception("Variable not declared")
                 else:
-                    expression += str(self.symbol_table.lookup(child.value).value)
+                    expression += str(self.symbol_table.lookup(child.value)['value']) # just call lookup and get value
             else:
                 expression += child.value
         return eval(expression)


### PR DESCRIPTION
This pull request resolves the global state issue in the SymbolTable.

- Moves the `symbols` list from a global variable to an instance variable within the `SymbolTable` class.
- This ensures that each interpreter session is completely isolated and prevents variable state from persisting across separate executions.
- Verified the fix by running two sequential programs where the second program correctly fails to find a variable defined only in the first.
<img width="586" height="129" alt="Screenshot From 2025-10-04 02-25-59" src="https://github.com/user-attachments/assets/8ee2ee4c-ca21-4204-a563-f8188fab111f" />
<img width="586" height="129" alt="Screenshot From 2025-10-04 02-26-45" src="https://github.com/user-attachments/assets/0270f1aa-2d10-46fd-9b37-1ad940f871c4" />

<img width="767" height="329" alt="Screenshot From 2025-10-04 02-27-10" src="https://github.com/user-attachments/assets/a6360ab9-a3a4-4958-8b74-c6c89dbc3d3d" />
<img width="935" height="212" alt="Screenshot From 2025-10-04 02-28-49" src="https://github.com/user-attachments/assets/c07c1e8b-47df-436a-a23b-121516866807" />

Fixes #17 
