### PR TITLE
Fix: Refactor loop_stmt to prevent RecursionError

### DIFF
--- a/doglang/main.py
+++ b/doglang/main.py
@@ -69,13 +69,11 @@ class Interpreter:
             body_nodes = [child for child in children if child.type != "expression"]
             
             if condition_node:
-                condition = self.expression_stmt(condition_node.children)
-                if condition:
-                    # Execute the body of the loop
+                # Use an iterative while loop instead of recursion
+                while self.expression_stmt(condition_node.children):
+                    # Execute each statement in the loop body
                     for node in body_nodes:
                         self.visit(node)
-                    # Then check the condition again (recursively)
-                    self.loop_stmt(children)
           
             
     def expression_stmt(self,children):


### PR DESCRIPTION
This pull request resolves a critical bug where the interpreter crashes with a `RecursionError: maximum recursion depth exceeded` when executing a `wagtail` loop with a large number of iterations (typically >1000).

The root cause was the recursive implementation of the `loop_stmt` method in the interpreter, where each loop iteration resulted in another function call, eventually overflowing the call stack. This fix makes the language more robust and capable of handling common, long-running loops.

### Implementation Details

I have refactored the `loop_stmt` function in `doglang/main.py` to use an iterative approach instead of a recursive one.

- The recursive call `self.loop_stmt(children)` has been replaced with a standard Python `while` loop.
- The loop's condition is evaluated using `self.expression_stmt()` at the beginning of each iteration.
- The body of the loop is then executed by visiting each of the body nodes.

This change eliminates the risk of stack overflow, allowing `wagtail` loops to run for a virtually unlimited number of iterations without crashing the interpreter.

### How This Was Tested

**Manual Verification:** I created a test file (`long_loop.doggy`) containing a `wagtail` loop set to run 2,000 iterations.
    -   **Before the fix:** The program crashed with a `RecursionError`.
    -   **After the fix:** The program now runs to completion successfully.

### Screenshots:
<img width="488" height="187" alt="Screenshot From 2025-10-06 21-05-50" src="https://github.com/user-attachments/assets/1e271c70-7620-4ad7-bdc0-3a8c81461072" />

<img width="967" height="99" alt="Screenshot From 2025-10-06 21-05-18" src="https://github.com/user-attachments/assets/d541a5f4-e530-42b3-8dbb-b1ec5d7dff01" />

Closes: #24 
Ready for review. Thank you!